### PR TITLE
feat: add `---@mod`

### DIFF
--- a/src/fixtures/test.lua
+++ b/src/fixtures/test.lua
@@ -1,3 +1,5 @@
+---@mod awesome-name Awesome module title
+
 local U = {}
 
 ---@brief [[

--- a/src/fixtures/test.lua
+++ b/src/fixtures/test.lua
@@ -1,4 +1,4 @@
----@mod awesome-name Awesome module title
+---@mod awesome.name Awesome module title
 
 local U = {}
 

--- a/src/parser/emmy.rs
+++ b/src/parser/emmy.rs
@@ -38,6 +38,7 @@ impl Display for Name {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TagType {
+    Module(String, Option<String>),
     Func(Name, String),
     Expr(Name, String),
     Export(String),
@@ -96,6 +97,10 @@ impl Emmy {
 
         let tags = just('@')
             .ignore_then(choice((
+                just("mod")
+                    .ignore_then(ty)
+                    .then(desc.clone())
+                    .map(|(tag, desc)| TagType::Module(tag, desc)),
                 just("func")
                     .ignore_then(dotted.clone())
                     .then(comment.clone())

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -120,16 +120,30 @@ impl LemmyHelp {
     }
 }
 
+// TOOD: move all the logic to method
 impl Display for LemmyHelp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(Node::Export(export)) = &self.nodes.last() {
+            let module = if let Some(Node::Module(Module { name, .. })) = &self.nodes.first() {
+                name
+            } else {
+                export
+            };
+
             for ele in &self.nodes {
                 match ele {
                     Node::Export(..) => {}
-                    Node::Func(Func { name, .. }) | Node::Type(Type { name, .. }) => {
-                        if let Name::Member(member, ..) = name {
+                    Node::Func(func) => {
+                        if let Name::Member(member, ..) = &func.name {
                             if member == export {
-                                writeln!(f, "{}", ele)?;
+                                writeln!(f, "{}", func.clone().rename_tag(module.to_string()))?;
+                            }
+                        }
+                    }
+                    Node::Type(typ) => {
+                        if let Name::Member(member, ..) = &typ.name {
+                            if member == export {
+                                writeln!(f, "{}", typ.clone().rename_tag(module.to_string()))?;
                             }
                         }
                     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -55,6 +55,7 @@ macro_rules! impl_parse {
 
 #[derive(Debug, Clone)]
 pub enum Node {
+    Module(Module),
     Brief(Brief),
     Tag(Tag),
     Func(Func),
@@ -68,6 +69,7 @@ pub enum Node {
 
 impl_parse!(Node, Option<Self>, {
     choice((
+        Module::parse().map(Self::Module),
         Brief::parse().map(Self::Brief),
         Tag::parse().map(Self::Tag),
         Func::parse().map(Self::Func),
@@ -94,6 +96,7 @@ impl Display for Node {
             Self::Class(x) => x.fmt(f),
             Self::Alias(x) => x.fmt(f),
             Self::Type(x) => x.fmt(f),
+            Self::Module(x) => x.fmt(f),
             _ => unimplemented!(),
         }
     }

--- a/src/parser/tags/func.rs
+++ b/src/parser/tags/func.rs
@@ -6,6 +6,7 @@ use crate::{child_table, impl_parse, section, Name, Object, TagType};
 
 #[derive(Debug, Clone)]
 pub struct Func {
+    pub tag: Name,
     pub name: Name,
     pub scope: String,
     pub desc: Vec<String>,
@@ -28,6 +29,7 @@ impl_parse!(Func, {
     .then(select! { TagType::Func(n, s) => (n, s) })
     .map(
         |(((((desc, params), returns), see), usage), (name, scope))| Self {
+            tag: name.clone(),
             name,
             scope,
             desc,
@@ -38,6 +40,16 @@ impl_parse!(Func, {
         },
     )
 });
+
+impl Func {
+    pub fn rename_tag(mut self, tag: String) -> Self {
+        if let Name::Member(_, field, kind) = self.tag {
+            self.tag = Name::Member(tag, field, kind)
+        };
+
+        self
+    }
+}
 
 impl Display for Func {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -97,7 +109,7 @@ impl Display for Func {
 
         let desc = self.desc.join("\n");
 
-        let section = section!(&name, self.name.to_string().as_str(), &desc, blocks);
+        let section = section!(&name, self.tag.to_string().as_str(), &desc, blocks);
 
         write!(f, "{}", section)
     }

--- a/src/parser/tags/mod.rs
+++ b/src/parser/tags/mod.rs
@@ -10,3 +10,5 @@ mod tag;
 pub use tag::*;
 mod r#type;
 pub use r#type::*;
+mod module;
+pub use module::*;

--- a/src/parser/tags/module.rs
+++ b/src/parser/tags/module.rs
@@ -1,0 +1,29 @@
+use std::fmt::Display;
+
+use chumsky::select;
+
+use crate::{impl_parse, TagType};
+
+#[derive(Debug, Clone)]
+pub struct Module {
+    pub name: String,
+    pub desc: Option<String>,
+}
+
+impl_parse!(Module, {
+    select! { TagType::Module(name, desc) => Self { name, desc } }
+});
+
+impl Display for Module {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let desc = self.desc.as_deref().unwrap_or_default();
+
+        writeln!(f, "{:=>80}", "")?;
+        writeln!(
+            f,
+            "{}{}",
+            desc,
+            format_args!("{:>w$}", format!("*{}*", self.name), w = 80 - desc.len())
+        )
+    }
+}

--- a/src/parser/tags/type.rs
+++ b/src/parser/tags/type.rs
@@ -7,6 +7,7 @@ use crate::{child_table, impl_parse, section, Name, TagType};
 #[derive(Debug, Clone)]
 pub struct Type {
     pub header: Vec<String>,
+    pub tag: Name,
     pub name: Name,
     pub scope: String,
     pub ty: String,
@@ -22,6 +23,7 @@ impl_parse!(Type, {
         .then(select! { TagType::Expr(name, scope) => (name, scope) })
         .map(|(((header, (ty, desc)), usage), (name, scope))| Self {
             header,
+            tag: name.clone(),
             name,
             scope,
             ty,
@@ -29,6 +31,16 @@ impl_parse!(Type, {
             usage,
         })
 });
+
+impl Type {
+    pub fn rename_tag(mut self, tag: String) -> Self {
+        if let Name::Member(_, field, kind) = self.tag {
+            self.tag = Name::Member(tag, field, kind)
+        };
+
+        self
+    }
+}
 
 impl Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -52,9 +64,10 @@ impl Display for Type {
         }
 
         let name = self.name.to_string();
+        let tag = self.tag.to_string();
         let desc = self.header.join("\n");
 
-        let section = section!(&name, &name, &desc, blocks).to_string();
+        let section = section!(&name, &tag, &desc, blocks).to_string();
 
         f.write_str(&section)
     }


### PR DESCRIPTION
### Syntax

```lua
---@mod <name> [desc]
```

> **NOTE: This should be the first tag in the file**

Example

```lua
---@mod my.module

---@mod new.module But with some description
```

### Behaviour

This tag enables the following and only affects the current file.

- Renders the module header

```help
================================================================================
But with some description                                           *new.module*
```

- Renames tag prefixes for all the **functions** and **types** with the module name.

```lua
---@mod awesome.name Awesome module title

local U = {}

---Add two integar and print it
---@param this number First number
---@param that number Second number
function U.sum(this, that)
	print(this + that)
end

---@class Human The Homosapien
---@field legs number Total number of legs
---@field hands number Total number of hands
---@field brain boolean Does humans have brain?

---Creates a Human
---@return Human
---@usage `require('Human'):create()`
function U:create()
	return setmetatable({
		legs = 2,
		hands = 2,
		brain = false,
	}, { __index = self })
end

return U
```

```help
================================================================================
Awesome module title                                              *awesome.name*

U.sum({this}, {that})                                         *awesome.name.sum*
    Add two integar and print it

    Parameters: ~
        {this}  (number)   First number
        {that}  (number)   Second number


Human                                                                    *Human*
    The Homosapien

    Fields: ~
        {legs}   (number)    Total number of legs
        {hands}  (number)    Total number of hands
        {brain}  (boolean)   Does humans have brain?


U:create()                                                 *awesome.name:create*
    Creates a Human

    Returns: ~
        {Human}

    Usage: ~
        >
          require('Human'):create()
        <
```

---

#### Obervations

- I left out the `.` or `:` before the name as IDK how to handle it properly.
- I consider using `---@module` but it was already [taken by LLS](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#module)