### PR TITLE
feat: enum support via `---@alias`

### DIFF
--- a/emmylua.md
+++ b/emmylua.md
@@ -7,7 +7,7 @@
 
 Following are the tags that you can use to create docs
 
-#### Brief
+### Brief
 
 A `brief` can be used to describe a module or even to add some footnote etc.
 
@@ -69,7 +69,7 @@ Some code blocks, but IDK whether it will be highlighted or not
 NOTE: remember there is no formatting or text wrapping
 ```
 
-#### Module
+### Module
 
 This tag can be used to add a heading for the module and change the prefix of every exported _function and type_.
 
@@ -141,7 +141,7 @@ U:create()                                                    *mod.Human:create*
         <
 ```
 
-#### Tag
+### Tag
 
 This can used to create an alternate tag for your module, functions etc.
 
@@ -155,7 +155,7 @@ This can used to create an alternate tag for your module, functions etc.
                                                               *another-cool-tag*
 ```
 
-#### Divider
+### Divider
 
 This tag can be used to add a divider/separator between section or anything you desire
 
@@ -179,7 +179,7 @@ This tag can be used to add a divider/separator between section or anything you 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
-#### Functions
+### Functions
 
 A function contains multiple tags which form its structure. Like `---@param` for parameter, `---@return` for the return value, `---@see` for other related things and `---@usage` for example
 
@@ -279,7 +279,7 @@ U.magical({this}, {that})                                            *U.magical*
         |U.sub|
 ```
 
-#### Class
+### Class
 
 Classes can be used to better structure your code and can be referenced as an argument to a function or it's return value. You can define it once and use it multiple times.
 
@@ -339,7 +339,7 @@ H:create()                                                            *H:create*
         <
 ```
 
-#### Type
+### Type
 
 You can use `---@type` to document static objects, constants etc.
 
@@ -393,7 +393,7 @@ U.chai                                                                  *U.chai*
         (Chai)
 ```
 
-#### Alias
+### Alias
 
 This can be used to make a type alias. It is helpful if you are using the same the type multiple times.
 
@@ -428,11 +428,48 @@ U.get_all()                                                          *U.get_all*
         {Lines}
 ```
 
+### Enum
+
+You can also define a (pseudo) enum using [`---@alias`](#alias).
+
+```lua
+local U = {}
+
+---@alias VMode
+---| 'line' Vertical motion
+---| 'char' Horizontal motion
+---| 'v'
+---| 'V' # Visual Line Mode
+
+---Global vim mode
+---@type VMode
+U.VMODE = 'line'
+
+return U
+```
+
+- Output
+
+```help
+VMode                                                                    *VMode*
+
+    Variants: ~
+        ('line')  Vertical motion
+        ('char')  Horizontal motion
+        ('v')
+        ('V')     Visual Line Mode
+
+
+U.VMODE                                                                *U.VMODE*
+    Global vim mode
+
+    Type: ~
+        (VMode)
+```
+
 ### Private
 
 You can use `---@private` tag to discard any part of the code that is exported but it is not considered to be a part of the public API
-
-> NOTE:
 
 ```lua
 local U = {}

--- a/src/parser/node.rs
+++ b/src/parser/node.rs
@@ -30,9 +30,7 @@ parser!(Node, Option<Self>, {
         Class::parse().map(Self::Class),
         Alias::parse().map(Self::Alias),
         Type::parse().map(Self::Type),
-        // We need this export to properly create the docs
-        // Like there is not point in creating docs for internal things
-        // NOTE: This is inserted by the lua parser
+        // We need this to match exported types/funcs etc.
         select! { TagType::Export(x) => Self::Export(x) },
     ))
     .map(Some)

--- a/src/parser/tags/alias.rs
+++ b/src/parser/tags/alias.rs
@@ -1,18 +1,42 @@
 use std::fmt::Display;
 
-use chumsky::select;
+use chumsky::{prelude::choice, select, Parser};
 
 use crate::{parser, TagType};
 
 #[derive(Debug, Clone)]
+pub struct TypeDef {
+    pub ty: String,
+    pub desc: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum AliasKind {
+    Type(TypeDef),
+    Enum(Vec<TypeDef>),
+}
+
+#[derive(Debug, Clone)]
 pub struct Alias {
-    name: String,
-    ty: String,
-    desc: Option<String>,
+    pub name: String,
+    pub kind: AliasKind,
 }
 
 parser!(Alias, {
-    select! { TagType::Alias { name, ty, desc } => Self { name, ty, desc } }
+    choice((
+        select! {
+            TagType::Alias { name, ty: Some(ty), desc } => {
+                Self { name, kind: AliasKind::Type(TypeDef { ty, desc }) }
+            },
+        },
+        select! { TagType::Alias { name, .. } => name }
+            .then(
+                select! { TagType::Variant(ty, desc) => TypeDef { ty, desc } }
+                    .repeated()
+                    .map(AliasKind::Enum),
+            )
+            .map(|(name, kind)| Self { name, kind }),
+    ))
 });
 
 impl Display for Alias {
@@ -20,10 +44,31 @@ impl Display for Alias {
         use crate::{description, header};
 
         header!(f, self.name)?;
-        description!(f, self.desc.as_deref().unwrap_or_default())?;
-        writeln!(f)?;
-        description!(f, "Type: ~")?;
-        writeln!(f, "{:>w$}", self.ty, w = 8 + self.ty.len())?;
+
+        match &self.kind {
+            AliasKind::Type(TypeDef { ty, desc }) => {
+                description!(f, desc.as_deref().unwrap_or_default())?;
+                writeln!(f)?;
+                description!(f, "Type: ~")?;
+                writeln!(f, "{:>w$}", ty, w = 8 + ty.len())?;
+            }
+            AliasKind::Enum(variants) => {
+                writeln!(f)?;
+                description!(f, "Variants: ~")?;
+
+                let mut table = tabular::Table::new("        {:<}  {:<}");
+                for v in variants {
+                    table.add_row(
+                        tabular::Row::new()
+                            .with_cell(&format!("({})", v.ty))
+                            .with_cell(v.desc.as_deref().unwrap_or_default()),
+                    );
+                }
+
+                write!(f, "{table}")?;
+            }
+        }
+
         writeln!(f)
     }
 }

--- a/src/parser/tags/class.rs
+++ b/src/parser/tags/class.rs
@@ -61,7 +61,7 @@ impl Display for Class {
                 }
             }
 
-            writeln!(f, "{}", table)?;
+            writeln!(f, "{table}")?;
         }
 
         if !self.see.refs.is_empty() {

--- a/src/parser/tags/func.rs
+++ b/src/parser/tags/func.rs
@@ -117,7 +117,7 @@ impl Display for Func {
                 );
             }
 
-            writeln!(f, "{}", table)?;
+            writeln!(f, "{table}")?;
         }
 
         if !self.returns.is_empty() {
@@ -138,7 +138,7 @@ impl Display for Func {
                 );
             }
 
-            writeln!(f, "{}", table)?;
+            writeln!(f, "{table}")?;
         }
 
         if !self.see.refs.is_empty() {

--- a/src/parser/tags/type.rs
+++ b/src/parser/tags/type.rs
@@ -80,7 +80,7 @@ impl Display for Type {
                 .with_cell(self.desc.as_deref().unwrap_or_default()),
         );
 
-        writeln!(f, "{}", table)?;
+        writeln!(f, "{table}")?;
 
         if let Some(usage) = &self.usage {
             writeln!(f, "{usage}")?;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -318,7 +318,15 @@ fn alias_and_type() {
     let src = r#"
     local U = {}
 
+    ---@alias NoDesc string
+
     ---@alias Lines string[] All the lines in the buffer
+
+    ---@alias VMode
+    ---| 'line' Vertical motion
+    ---| 'char' Horizontal motion
+    ---| 'v'
+    ---| 'V' # Visual Line Mode
 
     ---Returns all the content of the buffer
     ---@return Lines
@@ -330,6 +338,10 @@ fn alias_and_type() {
     ---@type Lines See |Lines|
     U.LINES = {}
 
+    ---Global vim mode
+    ---@type VMode
+    U.VMODE = 'line'
+
     return U
     "#;
 
@@ -340,11 +352,27 @@ fn alias_and_type() {
     assert_eq!(
         lemmy.to_string(),
         "\
+NoDesc                                                                  *NoDesc*
+
+
+    Type: ~
+        string
+
+
 Lines                                                                    *Lines*
     All the lines in the buffer
 
     Type: ~
         string[]
+
+
+VMode                                                                    *VMode*
+
+    Variants: ~
+        ('line')  Vertical motion
+        ('char')  Horizontal motion
+        ('v')     
+        ('V')     Visual Line Mode
 
 
 U.get_all()                                                          *U.get_all*
@@ -359,6 +387,13 @@ U.LINES                                                                *U.LINES*
 
     Type: ~
         (Lines)  See |Lines|
+
+
+U.VMODE                                                                *U.VMODE*
+    Global vim mode
+
+    Type: ~
+        (VMode)  
 
 
 "

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -126,4 +126,12 @@ function U.no_emmy()
     print('Private func with no emmylua!')
 end
 
+-- You can define a (psuedo) enum using `alias`
+
+---@alias VMode
+---| 'line' Vertical motion
+---| 'char' Horizontal motion
+---| 'v'
+---| 'V' # Visual Line Mode
+
 return U

--- a/todo.txt
+++ b/todo.txt
@@ -15,7 +15,7 @@
 [x] return with only type
 [x] support metamethods i.e. this:that()
 [x] check for exported `return`
-[ ] enum via @alias
+[x] enum via @alias
 [ ] also support string as an entry alongside path
 [x] long names
 [-] Non-Standard tags (should not interfere with LSP)


### PR DESCRIPTION
### Syntax

```lua
local U = {}

---@alias VMode
---| 'line' Vertical motion
---| 'char' Horizontal motion
---| 'v'
---| 'V' # Visual Line Mode

---Global vim mode
---@type VMode
U.VMODE = 'line'

return U
```

### Help

```help
VMode                                                                    *VMode*

    Variants: ~
        ('line')  Vertical motion
        ('char')  Horizontal motion
        ('v')
        ('V')     Visual Line Mode


U.VMODE                                                                *U.VMODE*
    Global vim mode

    Type: ~
        (VMode)
```