### PR TITLE
feat: allow desc in `---@alias` enum

### DIFF
--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -335,6 +335,7 @@ fn alias_and_type() {
     ---@alias Lines string[] All the lines in the buffer
 
     ---@alias VMode
+    ---Vim operator-mode motions. Read `:h map-operator`
     ---| 'line' Vertical motion
     ---| 'char' Horizontal motion
     ---| 'v'
@@ -379,6 +380,7 @@ Lines                                                                    *Lines*
 
 
 VMode                                                                    *VMode*
+    Vim operator-mode motions. Read `:h map-operator`
 
     Variants: ~
         ('line')  Vertical motion

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -129,6 +129,7 @@ end
 -- You can define a (psuedo) enum using `alias`
 
 ---@alias VMode
+---Vim operator-mode motions. Read `:h map-operator`
 ---| 'line' Vertical motion
 ---| 'char' Horizontal motion
 ---| 'v'


### PR DESCRIPTION
Now you can add a description to a `---@alias` (enum) tag

### Syntax

```lua
---@alias <name>
---TEXT                  <--- This is now valid
---TEXT                  <--- and there could be more than one
---| ...
---| ...
```

### Emmy

```lua
---@alias VMode
---Vim operator-mode motions. Read `:h map-operator`
---| 'line' Vertical motion
---| 'char' Horizontal motion
---| 'v' Visual Block Mode
---| 'V' # Visual Line Mode
```

### Help

```help
VMode                                                                    *VMode*
    Vim operator-mode motions. Read `:h map-operator`

    Variants: ~
        ('line')  Vertical motion
        ('char')  Horizontal motion
        ('v')     Visual Block Mode
        ('V')     Visual Line Mode
```