### PR TITLE
change!: description should appear first in enum

### DIFF
--- a/emmylua.md
+++ b/emmylua.md
@@ -435,8 +435,10 @@ You can also define a (pseudo) enum using [`---@alias`](#alias).
 ```lua
 local U = {}
 
+---Vim operator-mode motions.
+---
+---Read `:h map-operator`
 ---@alias VMode
----Vim operator-mode motions. Read `:h map-operator`
 ---| 'line' Vertical motion
 ---| 'char' Horizontal motion
 ---| 'v'
@@ -453,7 +455,9 @@ return U
 
 ```help
 VMode                                                                    *VMode*
-    Vim operator-mode motions. Read `:h map-operator`
+    Vim operator-mode motions.
+
+    Read `:h map-operator`
 
     Variants: ~
         ('line')  Vertical motion

--- a/src/parser/tags/alias.rs
+++ b/src/parser/tags/alias.rs
@@ -34,14 +34,18 @@ parser!(Alias, {
                 }
             },
         },
-        select! { TagType::Alias { name, .. } => name }
-            .then(select! { TagType::Comment(x) => x }.repeated())
-            .then(select! { TagType::Variant(ty, desc) => TypeDef { ty, desc } }.repeated())
-            .map(|((name, desc), variants)| Self {
-                name,
-                kind: AliasKind::Enum(desc, variants),
-                prefix: Prefix::default(),
-            }),
+        select! {
+            TagType::Comment(x) => x,
+            TagType::Empty => String::new()
+        }
+        .repeated()
+        .then(select! { TagType::Alias { name, .. } => name })
+        .then(select! { TagType::Variant(ty, desc) => TypeDef { ty, desc } }.repeated())
+        .map(|((desc, name), variants)| Self {
+            name,
+            kind: AliasKind::Enum(desc, variants),
+            prefix: Prefix::default(),
+        }),
     ))
 });
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -334,8 +334,10 @@ fn alias_and_type() {
 
     ---@alias Lines string[] All the lines in the buffer
 
+    ---Vim operator-mode motions.
+    ---
+    ---Read `:h map-operator`
     ---@alias VMode
-    ---Vim operator-mode motions. Read `:h map-operator`
     ---| 'line' Vertical motion
     ---| 'char' Horizontal motion
     ---| 'v'
@@ -380,7 +382,9 @@ Lines                                                                    *Lines*
 
 
 VMode                                                                    *VMode*
-    Vim operator-mode motions. Read `:h map-operator`
+    Vim operator-mode motions.
+
+    Read `:h map-operator`
 
     Variants: ~
         ('line')  Vertical motion

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -128,8 +128,10 @@ end
 
 -- You can define a (psuedo) enum using `alias`
 
+---Vim operator-mode motions.
+---
+---Read `:h map-operator`
 ---@alias VMode
----Vim operator-mode motions. Read `:h map-operator`
 ---| 'line' Vertical motion
 ---| 'char' Horizontal motion
 ---| 'v'


### PR DESCRIPTION
- Before

```lua
---@alias VMode
---Vim operator-mode motions. Read `:h map-operator`
---| 'line' Vertical motion
---| 'char' Horizontal motion
---| 'v'
---| 'V' # Visual Line Mode
```

- After

```lua
---Vim operator-mode motions. Read `:h map-operator`
---@alias VMode
---| 'line' Vertical motion
---| 'char' Horizontal motion
---| 'v'
---| 'V' # Visual Line Mode
```