### PR TITLE
feat: multiline `---@field` description

### DIFF
--- a/emmylua.md
+++ b/emmylua.md
@@ -186,6 +186,7 @@ A function contains multiple tags which form its structure. Like `---@param` for
 ```lua
 ---@comment
 ---@param <name> <type> <desc>
+---@comment
 ---@return <type> <name> <desc>
 ---@see <ref>
 ---@usage `<code>`
@@ -285,6 +286,7 @@ Classes can be used to better structure your code and can be referenced as an ar
 
 ```lua
 ---@class <name> <desc>
+---@comment
 ---@field [public|protected|private] <name> <type> <desc>
 ---@see <ref>
 ```
@@ -298,6 +300,9 @@ local H = {}
 ---@field legs number Total number of legs
 ---@field hands number Total number of hands
 ---@field brain boolean Does humans have brain?
+---Traits that one human can have
+---It could be one, two or hundered
+---@field trait table
 ---@field protected heart boolean Heart is protected
 ---@field private IQ number We need to hide this
 
@@ -325,6 +330,8 @@ Human                                                                    *Human*
         {legs}   (number)   Total number of legs
         {hands}  (number)   Total number of hands
         {brain}  (boolean)  Does humans have brain?
+        {trait}  (table)    Traits that one human can have
+                            It could be one, two or hundered
 
 
 H:create()                                                            *H:create*

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -113,6 +113,20 @@ fn classes() {
     ---@field protected __secret_1 number Secret ingredient first
     ---@field private __secret_2 number
 
+    ---@class CommentConfig Plugin's configuration
+    ---@field padding boolean Add a space b/w comment and the line
+    ---Whether the cursor should stay at its position
+    ---NOTE: This only affects NORMAL mode mappings and doesn't work with dot-repeat
+    ---
+    ---@field sticky boolean
+    ---Lines to be ignored while comment/uncomment.
+    ---Could be a regex string or a function that returns a regex string.
+    ---Example: Use '^$' to ignore empty lines
+    ---
+    ---@field ignore string|fun():string
+    ---@field pre_hook fun(ctx:CommentCtx):string Function to be called before comment/uncomment
+    ---@field post_hook fun(ctx:CommentCtx) Function to be called after comment/uncomment
+
     return U
     ";
 
@@ -140,6 +154,22 @@ SuperSecret                                                        *SuperSecret*
         {second}  (number)  Second ingredient
         {third}   (number)  Third ingredient
         {todo}    (number)
+
+
+CommentConfig                                                    *CommentConfig*
+    Plugin's configuration
+
+    Fields: ~
+        {padding}    (boolean)                     Add a space b/w comment and the line
+        {sticky}     (boolean)                     Whether the cursor should stay at its position
+                                                   NOTE: This only affects NORMAL mode mappings and doesn't work with dot-repeat
+
+        {ignore}     (string|fun():string)         Lines to be ignored while comment/uncomment.
+                                                   Could be a regex string or a function that returns a regex string.
+                                                   Example: Use '^$' to ignore empty lines
+
+        {pre_hook}   (fun(ctx:CommentCtx):string)  Function to be called before comment/uncomment
+        {post_hook}  (fun(ctx:CommentCtx))         Function to be called after comment/uncomment
 
 
 "

--- a/todo.txt
+++ b/todo.txt
@@ -2,14 +2,13 @@
 
 [x] optional description
 [x] simple comments (bcz comments can appear before @class)
-[ ] @vararg
 [x] optional parameters (but IDK how to render is nicely)
 [ ] expand `Ty`
 [x] description in return
 [x] consider 80 char width
 [x] @usage/@example
-[ ] multiline @params description
-[ ] support table as param
+[x] multiline @param description
+[x] multiline @field description
 [x] multiple @see reference
 [x] func w/ no returns or no params
 [x] return with only type
@@ -25,3 +24,7 @@
     [x] ---@private
     [ ] ---@toc-entry & ---@toc-slot
 [ ] Error handling
+
+## Dropped
+
+[ ] @vararg


### PR DESCRIPTION
It is now valid to have description for `---@field` over multiple lines. But keep in mind that multiline description should come before `---@field` definition

### Emmy

```lua
---@class CommentConfig Plugin's configuration
---@field padding boolean Add a space b/w comment and the line
---Whether the cursor should stay at its position
---NOTE: This only affects NORMAL mode mappings and doesn't work with dot-repeat
---
---@field sticky boolean
---Lines to be ignored while comment/uncomment.
---Could be a regex string or a function that returns a regex string.
---Example: Use '^$' to ignore empty lines
---
---@field ignore string|fun():string
---@field pre_hook fun(ctx:CommentCtx):string Function to be called before comment/uncomment
---@field post_hook fun(ctx:CommentCtx) Function to be called after comment/uncomment
```

### Help

```help
CommentConfig                                                    *CommentConfig*
    Plugin's configuration

    Fields: ~
        {padding}    (boolean)                     Add a space b/w comment and the line
        {sticky}     (boolean)                     Whether the cursor should stay at its position
                                                   NOTE: This only affects NORMAL mode mappings and doesn't work with dot-repeat
 
        {ignore}     (string|fun():string)         Lines to be ignored while comment/uncomment.
                                                   Could be a regex string or a function that returns a regex string.
                                                   Example: Use '^$' to ignore empty lines

        {pre_hook}   (fun(ctx:CommentCtx):string)  Function to be called before comment/uncomment
        {post_hook}  (fun(ctx:CommentCtx))         Function to be called after comment/uncomment
```