### PR TITLE
feat!: add `--prefix-func` and `--prefix-type` options

### DIFF
--- a/emmylua.md
+++ b/emmylua.md
@@ -9,7 +9,7 @@ Following are the tags that you can use to create docs
 
 ### Brief
 
-A `brief` can be used to describe a module or even to add some footnote etc.
+This tag can be used to describe a module or even to add some footnote etc.
 
 - Syntax
 
@@ -75,12 +75,14 @@ NOTE: remember there is no formatting or text wrapping
 
 ### Module
 
-This can be used to add a heading for the module and change the prefix of every exported _function and type_.
+This tag can be used to add a heading for a section. This tag also has the following properties:
 
-> NOTE:
->
-> 1. This can appear multiple times in a file but only the last `---@mod` will be used to rename prefixes.
-> 2. Also adds a entries in the [`Table of Contents`](#table-of-contents)
+1. This can appear multiple times in a file but only the last `---@mod` will be used to rename prefixes.
+
+   > Use `--prefix-{func,alias,class,type}` cli options to rename function, alias, class, and type name prefixes relatively
+   > See [`tests/renaming`](./tests/renaming.rs)
+
+2. Also adds a entries in the [`Table of Contents`](#table-of-contents)
 
 - Syntax
 
@@ -173,14 +175,14 @@ Human                                                                    *Human*
         {brain}  (boolean)  Does humans have brain?
 
 
-U.DEFAULT                                                    *mod.Human.DEFAULT*
+U.DEFAULT                                                            *U.DEFAULT*
     Default traits of a human
 
     Type: ~
         (Human)
 
 
-U:create()                                                    *mod.Human:create*
+U:create()                                                            *U:create*
     Creates a Human
 
     Returns: ~
@@ -194,7 +196,7 @@ U:create()                                                    *mod.Human:create*
 
 ### Table of Contents
 
-Following tag can be used to generate a _Table of Contents_ section. It uses [`---@mod`](#module) tags for the entries.
+This tag can be used to generate a _Table of Contents_ section. It uses [`---@mod`](#module) tags for the entries.
 
 - Syntax
 
@@ -240,7 +242,7 @@ Third Module                                                      *third.module*
 
 ### Tag
 
-This can used to create an alternate tag for your module, functions etc.
+This tag can used to create an alternate tag for your module, functions etc.
 
 - Syntax
 
@@ -525,7 +527,7 @@ U.chai                                                                  *U.chai*
 
 ### Alias
 
-This can be used to make a type alias. It is helpful if you are using the same the type multiple times.
+This tag can be used to make a type alias. It is helpful if you are using the same the type multiple times.
 
 - Syntax
 
@@ -568,7 +570,7 @@ U.get_all()                                                          *U.get_all*
 
 ### Enum
 
-You can also define a (pseudo) enum using [`---@alias`](#alias).
+You can define a (pseudo) enum using [`---@alias`](#alias).
 
 - Input
 
@@ -615,7 +617,13 @@ U.VMODE                                                                *U.VMODE*
 
 ### Private
 
-You can use `---@private` tag to discard any part of the code that is exported but it is not considered to be a part of the public API
+This tag can be used to discard any part of the code that is exported but it is not considered to be a part of the public API
+
+- Syntax
+
+```lua
+---@private
+```
 
 - Input
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,8 +42,10 @@ impl Cli {
                     std::process::exit(0);
                 }
                 Short('M') | Long("no-modeline") => c.modeline = false,
+                Short('f') | Long("prefix-func") => c.rename.func = true,
                 Short('a') | Long("prefix-alias") => c.rename.alias = true,
                 Short('c') | Long("prefix-class") => c.rename.class = true,
+                Short('t') | Long("prefix-type") => c.rename.r#type = true,
                 Value(val) => {
                     let file = PathBuf::from(&val);
 
@@ -93,8 +95,10 @@ ARGS:
 
 OPTIONS:
     -M, --no-modeline       Don't print modeline at the end
-    -a, --prefix-alias      Prefix ---@alias tag with return/mod name
-    -c, --prefix-class      Prefix ---@class tag with return/mod name
+    -f, --prefix-func       Prefix function name with ---@mod name
+    -a, --prefix-alias      Prefix ---@alias tag with return/---@mod name
+    -c, --prefix-class      Prefix ---@class tag with return/---@mod name
+    -t, --prefix-type       Prefix ---@type tag with ---@mod name
     -h, --help              Print help information
     -v, --version           Print version information
 
@@ -104,7 +108,6 @@ USAGE:
 
 NOTES:
     - The order of parsing + rendering is relative to the given files
-    - Types and Functions will be prefixed with ---@mod name
 "
         );
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -38,8 +38,14 @@ use chumsky::{prelude::Simple, Parser, Stream};
 
 #[derive(Debug, Default)]
 pub struct Rename {
+    /// Prefix `function` name with `---@mod` name
+    pub func: bool,
+    /// Prefix `---@alias` tag with `return/---@mod` name
     pub alias: bool,
+    /// Prefix ---@class tag with return/---@mod name
     pub class: bool,
+    /// Prefix `---@type` tag with `---@mod` name
+    pub r#type: bool,
 }
 
 #[derive(Debug, Default)]
@@ -77,15 +83,17 @@ impl LemmyHelp {
                     Node::Export(..) => {}
                     Node::Func(mut func) => {
                         if func.is_public(&export) {
-                            func.rename_tag(module.to_owned());
-
+                            if self.rename.func {
+                                func.rename_tag(module.to_owned());
+                            }
                             self.nodes.push(Node::Func(func));
                         }
                     }
                     Node::Type(mut typ) => {
                         if typ.is_public(&export) {
-                            typ.rename_tag(module.to_owned());
-
+                            if self.rename.r#type {
+                                typ.rename_tag(module.to_owned());
+                            }
                             self.nodes.push(Node::Type(typ));
                         }
                     }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -352,14 +352,14 @@ Human                                                                    *Human*
         {brain}  (boolean)  Does humans have brain?
 
 
-U.DEFAULT                                                    *mod.Human.DEFAULT*
+U.DEFAULT                                                            *U.DEFAULT*
     Default traits of a human
 
     Type: ~
         (Human)
 
 
-U:create()                                                    *mod.Human:create*
+U:create()                                                            *U:create*
     Creates a Human
 
     Returns: ~

--- a/tests/renaming.rs
+++ b/tests/renaming.rs
@@ -1,26 +1,39 @@
 use lemmy_help::{LemmyHelp, Rename};
 
+const CODE: &str = r#"
+local U = {}
+
+---@alias ID string
+
+---@class User
+---@field name string
+---@field email string
+---@field id ID
+
+---A Pi
+---@type number
+U.Pi = 3.14
+
+---Creates a PI
+---@return number
+---@usage `require('Pi'):create()`
+function U:create()
+    return self.Pi
+end
+
+return U
+"#;
+
 #[test]
 fn rename_with_return() {
-    let src = r#"
-    local U = {}
-
-    ---@alias ID string
-
-    ---@class User
-    ---@field name string
-    ---@field email string
-    ---@field id ID
-
-    return U
-    "#;
-
     let mut lemmy = LemmyHelp::with_rename(Rename {
-        class: true,
+        func: true,
         alias: true,
+        class: true,
+        r#type: true,
     });
 
-    lemmy.for_help(src).unwrap();
+    lemmy.for_help(CODE).unwrap();
 
     assert_eq!(
         lemmy.to_string(),
@@ -41,33 +54,41 @@ User                                                                    *U.User*
         {id}     (ID)
 
 
+U.Pi                                                                      *U.Pi*
+    A Pi
+
+    Type: ~
+        (number)
+
+
+U:create()                                                            *U:create*
+    Creates a PI
+
+    Returns: ~
+        {number}
+
+    Usage: ~
+        >
+            require('Pi'):create()
+        <
+
+
 "
     );
 }
 
 #[test]
 fn rename_with_mod() {
-    let src = r#"
-    ---@mod awesome This is working
-
-    local U = {}
-
-    ---@alias ID string
-
-    ---@class User
-    ---@field name string
-    ---@field email string
-    ---@field id ID
-
-    return U
-    "#;
+    let src = format!("---@mod awesome This is working {CODE}");
 
     let mut lemmy = LemmyHelp::with_rename(Rename {
-        class: true,
+        func: true,
         alias: true,
+        class: true,
+        r#type: true,
     });
 
-    lemmy.for_help(src).unwrap();
+    lemmy.for_help(&src).unwrap();
 
     assert_eq!(
         lemmy.to_string(),
@@ -89,6 +110,25 @@ User                                                              *awesome.User*
         {name}   (string)
         {email}  (string)
         {id}     (ID)
+
+
+U.Pi                                                                *awesome.Pi*
+    A Pi
+
+    Type: ~
+        (number)
+
+
+U:create()                                                      *awesome:create*
+    Creates a PI
+
+    Returns: ~
+        {number}
+
+    Usage: ~
+        >
+            require('Pi'):create()
+        <
 
 
 "


### PR DESCRIPTION
Now `function` and `---@type` are no longer automatically prefixed with the `---@mod` name.

Use the new options to get the old behavior