### PR TITLE
feat: add `---@export`

### DIFF
--- a/emmylua.md
+++ b/emmylua.md
@@ -688,3 +688,54 @@ return U
 U.ok()                                                                    *U.ok*
     Only this will be documented
 ```
+
+### Export
+
+This tag is used to manually tag the exported object. This is required for cases where `lemmy-help` is unable to parse the `return` statement at the end such as `return setmetatable(...)`. But keep in mind the following:
+
+1. Anything after this tag is NA, so make sure this is the last tag
+2. Tag should be followed by the exact identifier that needs to be exported
+3. This has nothing to do with `---@mod`
+
+- Syntax
+
+```lua
+---@export <name>
+```
+
+- Input
+
+```lua
+---@mod module.config Configuration
+
+local Config = {}
+
+---Get the config
+---@return number
+function Config:get()
+    return 3.14
+end
+
+---@export Config
+return setmetatable(Config, {
+    __index = function(this, k)
+        return this.state[k]
+    end,
+    __newindex = function(this, k, v)
+        this.state[k] = v
+    end,
+})
+```
+
+- Output
+
+```help
+================================================================================
+Configuration                                                    *module.config*
+
+Config:get()                                                        *Config:get*
+    Get the config
+
+    Returns: ~
+        {number}
+```

--- a/src/parser/emmy.rs
+++ b/src/parser/emmy.rs
@@ -216,6 +216,11 @@ impl Emmy {
                 )
                 .collect()
                 .map(TagType::Usage),
+            just("export")
+                .then(whitespace())
+                .ignore_then(ident())
+                .then_ignore(take_until(end()))
+                .map(TagType::Export),
         )));
 
         choice((
@@ -250,7 +255,7 @@ impl Emmy {
                 expr.map(|(prefix, kind, name)| TagType::Expr { prefix, name, kind }),
             )),
             keyword("return")
-                .ignore_then(ident().padded())
+                .ignore_then(name)
                 .then_ignore(end())
                 .map(TagType::Export),
             misc.to(TagType::Skip),

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -632,3 +632,48 @@ U.ok()                                                                    *U.ok*
 "
     )
 }
+
+#[test]
+fn export() {
+    let src = "
+    ---@mod module.config Configuration
+
+    local Config = {}
+
+    ---Get the config
+    ---@return number
+    function Config:get()
+        return 3.14
+    end
+
+    ---@export Config
+    return setmetatable(Config, {
+        __index = function(this, k)
+            return this.state[k]
+        end,
+        __newindex = function(this, k, v)
+            this.state[k] = v
+        end,
+    })
+    ";
+
+    let mut lemmy = LemmyHelp::default();
+
+    lemmy.for_help(src).unwrap();
+
+    assert_eq!(
+        lemmy.to_string(),
+        "\
+================================================================================
+Configuration                                                    *module.config*
+
+Config:get()                                                        *Config:get*
+    Get the config
+
+    Returns: ~
+        {number}
+
+
+"
+    )
+}

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -1,3 +1,5 @@
+---@toc test.contents
+
 ---@mod mod.intro Introduction
 ---@brief [[
 ---
@@ -17,8 +19,6 @@
 ---<
 ---
 ---@brief ]]
-
----@toc test.contents
 
 ---@mod awesome.name Awesome module title
 


### PR DESCRIPTION
This tag allows us to manually tag the exported object. As the parser is unable to parse some `return` cases, such as `return setmetatable(...)`

### Emmylua

```lua
---@mod module.config Configuration

local Config = {}

---Get the config
---@return number
function Config:get()
    return 3.14
end

---@export Config
return setmetatable(Config, {
    __index = function(this, k)
        return this.state[k]
    end,
    __newindex = function(this, k, v)
        this.state[k] = v
    end,
})
```

### Help

```help
================================================================================
Configuration                                                    *module.config*

Config:get()                                                        *Config:get*
    Get the config

    Returns: ~
        {number}
```