### PR TITLE
fix: bring back `[desc]` support in `---@type`

### DIFF
--- a/emmylua.md
+++ b/emmylua.md
@@ -532,7 +532,7 @@ You can use `---@type` to document static objects, constants etc.
 
 ```lua
 ---@comment
----@type <type>
+---@type <type> [desc]
 ---@see <tag>
 ---@usage `<code>`
 ```

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -118,9 +118,9 @@ pub enum TagType {
     /// ```
     Variant(String, Option<String>),
     /// ```lua
-    /// ---@type <type>
+    /// ---@type <type> [desc]
     /// ```
-    Type(String),
+    Type(String, Option<String>),
     /// ```lua
     /// ---@tag <name>
     /// ```
@@ -273,7 +273,8 @@ impl Lexer {
             just("type")
                 .ignore_then(space)
                 .ignore_then(ty)
-                .map(TagType::Type),
+                .then(desc)
+                .map(|(ty, desc)| TagType::Type(ty, desc)),
             just("tag")
                 .ignore_then(space)
                 .ignore_then(comment)

--- a/src/parser/tags/type.rs
+++ b/src/parser/tags/type.rs
@@ -9,9 +9,9 @@ use super::Usage;
 
 #[derive(Debug, Clone)]
 pub struct Type {
-    pub desc: Vec<String>,
     pub prefix: Prefix,
     pub name: String,
+    pub desc: (Vec<String>, Option<String>),
     pub kind: Kind,
     pub ty: String,
     pub see: See,
@@ -23,22 +23,24 @@ impl_parse!(Type, {
         TagType::Comment(x) => x
     }
     .repeated()
-    .then(select! { TagType::Type(ty) => ty })
+    .then(select! { TagType::Type(ty, desc) => (ty, desc) })
     .then(See::parse())
     .then(Usage::parse().or_not())
     .then(select! { TagType::Expr { prefix, name, kind } => (prefix, name, kind) })
-    .map(|((((desc, ty), see), usage), (prefix, name, kind))| Self {
-        desc,
-        prefix: Prefix {
-            left: prefix.clone(),
-            right: prefix,
+    .map(
+        |((((extract, (ty, desc)), see), usage), (prefix, name, kind))| Self {
+            desc: (extract, desc),
+            prefix: Prefix {
+                left: prefix.clone(),
+                right: prefix,
+            },
+            name,
+            kind,
+            ty,
+            see,
+            usage,
         },
-        name,
-        kind,
-        ty,
-        see,
-        usage,
-    })
+    )
 });
 
 impl Type {

--- a/src/vimdoc/type.rs
+++ b/src/vimdoc/type.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use crate::parser::Type;
 
-use super::{description, header, see::SeeDoc, usage::UsageDoc};
+use super::{description, header, see::SeeDoc, usage::UsageDoc, Table};
 
 #[derive(Debug)]
 pub struct TypeDoc<'a>(pub &'a Type);
@@ -10,7 +10,7 @@ pub struct TypeDoc<'a>(pub &'a Type);
 impl Display for TypeDoc<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Type {
-            desc,
+            desc: (extract, desc),
             prefix,
             name,
             kind,
@@ -35,18 +35,18 @@ impl Display for TypeDoc<'_> {
             )
         )?;
 
-        if !desc.is_empty() {
-            description!(f, &desc.join("\n"))?;
+        if !extract.is_empty() {
+            description!(f, &extract.join("\n"))?;
         }
 
         writeln!(f)?;
 
         description!(f, "Type: ~")?;
-        f.write_fmt(format_args!(
-            "{:>w$}\n\n",
-            format!("({})", ty),
-            w = 10 + ty.len()
-        ))?;
+
+        let mut table = Table::new();
+        table.add_row([&format!("({})", ty), desc.as_deref().unwrap_or_default()]);
+
+        writeln!(f, "{table}")?;
 
         if !see.refs.is_empty() {
             writeln!(f, "{}", SeeDoc(see))?;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -546,8 +546,8 @@ fn alias_and_type() {
 
     ---List of all the lines in the buffer
     ---It can be more than one
-    ---@type Lines
-    ---@see something
+    ---@type Lines lines in a buffer
+    ---@see Lines
     U.LINES = {}
 
     ---Global vim mode
@@ -601,10 +601,10 @@ U.LINES                                                                *U.LINES*
     It can be more than one
 
     Type: ~
-        (Lines)
+        (Lines)  lines in a buffer
 
     See: ~
-        |something|
+        |Lines|
 
 
 U.VMODE                                                                *U.VMODE*


### PR DESCRIPTION
This PR brings back `[desc]` support in `---@type` which was removed in #37