### PR TITLE
feat: optional `---@field`

### DIFF
--- a/emmylua.md
+++ b/emmylua.md
@@ -297,7 +297,7 @@ A function contains multiple tags which form its structure. Like `---@param` for
 
 ```lua
 ---@comment
----@param <name> <type> [desc]
+---@param <name[?]> <type[|type...]> [description]
 ---@comment
 ---@return <type> [<name> [comment] | [name] #<comment>]
 ---@comment
@@ -462,7 +462,7 @@ Classes can be used to better structure your code and can be referenced as an ar
 ---@comment
 ---@class <name>
 ---@comment
----@field [public|protected|private] <name> <type> [desc]
+---@field [public|protected|private] <name[?]> <type> [desc]
 ---@see <ref>
 ```
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -217,13 +217,13 @@ impl Lexer {
                 .ignore_then(space.ignore_then(scope).or_not())
                 .then_ignore(space)
                 .then(ident())
+                .then(optional)
                 .then_ignore(space)
                 .then(ty.clone())
                 .then(desc)
-                .map(|(((scope, name), ty), desc)| TagType::Field {
+                .map(|((((scope, name), opt), ty), desc)| TagType::Field {
                     scope: scope.unwrap_or(Scope::Public),
-                    name,
-                    ty,
+                    tyval: opt(name, ty),
                     desc,
                 }),
             just("alias")

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -63,12 +63,11 @@ pub enum TagType {
     /// ```
     Class(String),
     /// ```lua
-    /// ---@field [public|private|protected] <name> <type> [description]
+    /// ---@field [public|private|protected] <name[?]> <type> [description]
     /// ```
     Field {
         scope: Scope,
-        name: String,
-        ty: Ty,
+        tyval: TypeVal,
         desc: Option<String>,
     },
     /// ```lua

--- a/src/parser/tags/class.rs
+++ b/src/parser/tags/class.rs
@@ -1,15 +1,14 @@
 use chumsky::{select, Parser};
 
 use crate::{
-    lexer::{Scope, TagType, Ty},
+    lexer::{Scope, TagType, TypeVal},
     parser::{impl_parse, Prefix, See},
 };
 
 #[derive(Debug, Clone)]
 pub struct Field {
     pub scope: Scope,
-    pub name: String,
-    pub ty: Ty,
+    pub tyval: TypeVal,
     pub desc: Vec<String>,
 }
 
@@ -19,20 +18,15 @@ impl_parse!(Field, {
     }
     .repeated()
     .then(select! {
-        TagType::Field { scope, name, ty, desc } => (scope, name, ty, desc)
+        TagType::Field { scope, tyval, desc } => (scope, tyval, desc)
     })
-    .map(|(header, (scope, name, ty, desc))| {
+    .map(|(header, (scope, tyval, desc))| {
         let desc = match desc {
             Some(d) => vec![d],
             None => header,
         };
 
-        Self {
-            scope,
-            name,
-            ty,
-            desc,
-        }
+        Self { scope, tyval, desc }
     })
 });
 

--- a/src/vimdoc/class.rs
+++ b/src/vimdoc/class.rs
@@ -1,6 +1,9 @@
 use std::fmt::Display;
 
-use crate::{lexer::Scope, parser::Class};
+use crate::{
+    lexer::{Scope, TypeVal},
+    parser::Class,
+};
 
 use super::{description, header, see::SeeDoc, Table};
 
@@ -18,7 +21,7 @@ impl Display for ClassDoc<'_> {
         } = self.0;
 
         if let Some(prefix) = &prefix.right {
-            header!(f, name, format!("{prefix}.{}", name))?;
+            header!(f, name, format!("{prefix}.{name}"))?;
         } else {
             header!(f, name)?;
         }
@@ -35,11 +38,11 @@ impl Display for ClassDoc<'_> {
 
             for field in fields {
                 if field.scope == Scope::Public {
-                    table.add_row([
-                        &format!("{{{}}}", field.name),
-                        &format!("({})", field.ty),
-                        &field.desc.join("\n"),
-                    ]);
+                    let (name, ty) = match &field.tyval {
+                        TypeVal::Opt(n, t) => (format!("{{{n}?}}"), format!("({t})")),
+                        TypeVal::Req(n, t) => (format!("{{{n}}}"), format!("({t})")),
+                    };
+                    table.add_row([name, ty, field.desc.join("\n")]);
                 }
             }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -108,11 +108,11 @@ fn classes() {
 
     ---@class SuperSecret
     ---@field first number First ingredient
-    ---@field public second number Second ingredient
+    ---@field public second? number Second ingredient
     ---@field third number Third ingredient
-    ---@field todo number
+    ---@field todo? number
     ---@field protected __secret_1 number Secret ingredient first
-    ---@field private __secret_2 number
+    ---@field private __secret_2? number
 
     ---Plugin's configuration
     ---@class CommentConfig
@@ -151,10 +151,10 @@ Human                                                                    *Human*
 SuperSecret                                                        *SuperSecret*
 
     Fields: ~
-        {first}   (number)  First ingredient
-        {second}  (number)  Second ingredient
-        {third}   (number)  Third ingredient
-        {todo}    (number)
+        {first}    (number)  First ingredient
+        {second?}  (number)  Second ingredient
+        {third}    (number)  Third ingredient
+        {todo?}    (number)
 
 
 CommentConfig                                                    *CommentConfig*


### PR DESCRIPTION
Now class `---@field` is allowed to be optional. New syntax looks like

```lua
---@field [public|private|protected] <name[?]> <type> [description]
```

Resolves #54 