### PR TITLE
feat: support deep access

### DIFF
--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -18,20 +18,12 @@ pub enum TagType {
     /// function one.two() end
     /// one.two = function() end
     /// ```
-    Func {
-        prefix: Option<String>,
-        name: String,
-        kind: Kind,
-    },
+    Func(String, Op),
     /// ```lua
     /// one = 1
     /// one.two = 12
     /// ```
-    Expr {
-        prefix: Option<String>,
-        name: String,
-        kind: Kind,
-    },
+    Expr(String, Op),
     /// ```lua
     /// ---@export <module>
     /// or
@@ -107,16 +99,29 @@ pub enum TagType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Kind {
-    Dot,
-    Colon,
+pub enum Op {
+    Deep(Vec<Op>),
+    Dot(String),
+    Colon(String),
 }
 
-impl Kind {
-    pub fn as_char(&self) -> char {
+impl Display for Op {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Dot => '.',
-            Self::Colon => ':',
+            Self::Deep(mixed) => {
+                for mix in mixed {
+                    mix.fmt(f)?;
+                }
+                Ok(())
+            }
+            Self::Dot(dot) => {
+                f.write_str(".")?;
+                f.write_str(dot)
+            }
+            Self::Colon(colon) => {
+                f.write_str(":")?;
+                f.write_str(colon)
+            }
         }
     }
 }

--- a/src/parser/tags/func.rs
+++ b/src/parser/tags/func.rs
@@ -1,7 +1,7 @@
 use chumsky::{select, Parser};
 
 use crate::{
-    lexer::{Kind, Name, TagType, Ty},
+    lexer::{Name, Op, TagType, Ty},
     parser::{impl_parse, Prefix, See},
 };
 
@@ -62,8 +62,7 @@ impl_parse!(Return, {
 
 #[derive(Debug, Clone)]
 pub struct Func {
-    pub name: String,
-    pub kind: Kind,
+    pub op: Op,
     pub prefix: Prefix,
     pub desc: Vec<String>,
     pub params: Vec<Param>,
@@ -81,14 +80,13 @@ impl_parse!(Func, {
     .then(Return::parse().repeated())
     .then(See::parse())
     .then(Usage::parse().or_not())
-    .then(select! { TagType::Func { prefix, name, kind } => (prefix, name, kind) })
+    .then(select! { TagType::Func(prefix, op) => (prefix, op) })
     .map(
-        |(((((desc, params), returns), see), usage), (prefix, name, kind))| Self {
-            name,
-            kind,
+        |(((((desc, params), returns), see), usage), (prefix, op))| Self {
+            op,
             prefix: Prefix {
-                left: prefix.clone(),
-                right: prefix,
+                left: Some(prefix.clone()),
+                right: Some(prefix),
             },
             desc,
             params,

--- a/src/parser/tags/type.rs
+++ b/src/parser/tags/type.rs
@@ -1,7 +1,7 @@
 use chumsky::{select, Parser};
 
 use crate::{
-    lexer::{Kind, TagType, Ty},
+    lexer::{Op, TagType, Ty},
     parser::{impl_parse, Prefix, See},
 };
 
@@ -9,10 +9,9 @@ use super::Usage;
 
 #[derive(Debug, Clone)]
 pub struct Type {
-    pub prefix: Prefix,
-    pub name: String,
     pub desc: (Vec<String>, Option<String>),
-    pub kind: Kind,
+    pub op: Op,
+    pub prefix: Prefix,
     pub ty: Ty,
     pub see: See,
     pub usage: Option<Usage>,
@@ -26,16 +25,15 @@ impl_parse!(Type, {
     .then(select! { TagType::Type(ty, desc) => (ty, desc) })
     .then(See::parse())
     .then(Usage::parse().or_not())
-    .then(select! { TagType::Expr { prefix, name, kind } => (prefix, name, kind) })
+    .then(select! { TagType::Expr(prefix, op) => (prefix, op) })
     .map(
-        |((((extract, (ty, desc)), see), usage), (prefix, name, kind))| Self {
+        |((((extract, (ty, desc)), see), usage), (prefix, op))| Self {
             desc: (extract, desc),
             prefix: Prefix {
-                left: prefix.clone(),
-                right: prefix,
+                left: Some(prefix.to_owned()),
+                right: Some(prefix),
             },
-            name,
-            kind,
+            op,
             ty,
             see,
             usage,

--- a/src/vimdoc/func.rs
+++ b/src/vimdoc/func.rs
@@ -19,28 +19,17 @@ impl ToDoc for FuncDoc {
                 .join(", ");
 
             format!(
-                "{}{}{}({args})",
+                "{}{}({args})",
                 n.prefix.left.as_deref().unwrap_or_default(),
-                n.kind.as_char(),
-                n.name
+                n.op
             )
         } else {
-            format!(
-                "{}{}{}()",
-                n.prefix.left.as_deref().unwrap_or_default(),
-                n.kind.as_char(),
-                n.name
-            )
+            format!("{}{}()", n.prefix.left.as_deref().unwrap_or_default(), n.op)
         };
 
         doc.push_str(&header!(
             name_with_param,
-            &format!(
-                "{}{}{}",
-                n.prefix.right.as_deref().unwrap_or_default(),
-                n.kind.as_char(),
-                n.name,
-            )
+            &format!("{}{}", n.prefix.right.as_deref().unwrap_or_default(), n.op)
         ));
 
         if !n.desc.is_empty() {

--- a/src/vimdoc/type.rs
+++ b/src/vimdoc/type.rs
@@ -11,18 +11,8 @@ impl ToDoc for TypeDoc {
         let mut doc = String::new();
 
         doc.push_str(&header!(
-            &format!(
-                "{}{}{}",
-                n.prefix.left.as_deref().unwrap_or_default(),
-                n.kind.as_char(),
-                n.name
-            ),
-            &format!(
-                "{}{}{}",
-                n.prefix.right.as_deref().unwrap_or_default(),
-                n.kind.as_char(),
-                n.name
-            )
+            &format!("{}{}", n.prefix.left.as_deref().unwrap_or_default(), n.op),
+            &format!("{}{}", n.prefix.right.as_deref().unwrap_or_default(), n.op)
         ));
 
         let (extract, desc) = &n.desc;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -179,7 +179,7 @@ CommentConfig                                                    *CommentConfig*
 #[test]
 fn functions() {
     let src = r#"
-    local U = {}
+    local U = { foo = {} }
 
     ---NOTE: Local functions are not part of the documentation
     ---Multiply two integer and print it
@@ -231,6 +231,19 @@ fn functions() {
     ---@param x integer
     ---@param ... unknown
     function U.with_var_arg_end(x, ...) end
+
+    ---Class method deep access
+    ---@return table
+    function U.foo:bar()
+        self.__index = self
+        return setmetatable({}, self)
+    end
+
+    ---Method deep access
+    ---@return table
+    function U.foo.baz()
+        return U.foo:bar()
+    end
 
     return U
     "#;
@@ -297,6 +310,20 @@ U.with_var_arg_end({x}, {...})                              *U.with_var_arg_end*
     Parameters: ~
         {x}    (integer)
         {...}  (unknown)
+
+
+U.foo:bar()                                                          *U.foo:bar*
+    Class method deep access
+
+    Returns: ~
+        (table)
+
+
+U.foo.baz()                                                          *U.foo.baz*
+    Method deep access
+
+    Returns: ~
+        (table)
 
 
 "


### PR DESCRIPTION
This adds support for parsing deep-access objects. Previously, following code

```lua
local U = {}

---Foo
---@type table
U.foo = {}

---Bar
---@return table
function U.foo:bar()
    self.__index = self
    return setmetatable({}, self)
end

---Baz
---@return table
function U.foo.baz()
    return U.foo:bar()
end

return U
```

Was rendered as the following, look how `bar()` and `baz()` methods are missing.

```help
U.foo                                                                    *U.foo*
    Foo

    Type: ~
        (table)


U.foo()                                                                  *U.foo*
    Bar

    Returns: ~
        (table)


U.foo()                                                                  *U.foo*
    Baz

    Returns: ~
        (table)
```

Now with this PR, it is rendered as expected

```help
U.foo                                                                    *U.foo*
    Foo

    Type: ~
        (table)


U.foo:bar()                                                          *U.foo:bar*
    Bar

    Returns: ~
        (table)


U.foo.baz()                                                          *U.foo.baz*
    Baz

    Returns: ~
        (table)
```