### PR TITLE
feat: support `---@class <name>[: <parent>]`

### DIFF
--- a/emmylua.md
+++ b/emmylua.md
@@ -460,7 +460,7 @@ Classes can be used to better structure your code and can be referenced as an ar
 
 ```lua
 ---@comment
----@class <name>
+---@class <name>[: <parent>]
 ---@comment
 ---@field [public|protected|private] <name[?]> <type> [desc]
 ---@see <ref>
@@ -483,6 +483,9 @@ local H = {}
 ---@field trait table
 ---@field protected heart boolean Heart is protected
 ---@field private IQ number We need to hide this
+
+---@class XMen : Human
+---@field power number Power quantifier
 
 ---Creates a Human
 ---@return Human
@@ -510,6 +513,12 @@ Human                                                                    *Human*
         {brain}  (boolean)  Does humans have brain?
         {trait}  (table)    Traits that one human can have
                             It could be one, two or hundered
+
+
+XMen : Homosapien                                                         *XMen*
+
+    Fields: ~
+        {power}  (number)  Power quantifier
 
 
 H:create()                                                            *H:create*

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -215,7 +215,8 @@ impl Lexer {
             just("class")
                 .ignore_then(space)
                 .ignore_then(name)
-                .map(TagType::Class),
+                .then(just(':').padded().ignore_then(ident()).or_not())
+                .map(|(name, parent)| TagType::Class(name, parent)),
             just("field")
                 .ignore_then(space.ignore_then(scope).or_not())
                 .then_ignore(space)

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -47,9 +47,9 @@ pub enum TagType {
     /// ```
     Return(Ty, Option<String>, Option<String>),
     /// ```lua
-    /// ---@class <name>
+    /// ---@class <name>[: <parent>]
     /// ```
-    Class(String),
+    Class(String, Option<String>),
     /// ```lua
     /// ---@field [public|private|protected] <name[?]> <type> [description]
     /// ```

--- a/src/parser/tags/class.rs
+++ b/src/parser/tags/class.rs
@@ -44,6 +44,7 @@ impl_parse!(Field, {
 #[derive(Debug, Clone)]
 pub struct Class {
     pub name: String,
+    pub parent: Option<String>,
     pub desc: Vec<String>,
     pub fields: Vec<Field>,
     pub see: See,
@@ -53,11 +54,12 @@ pub struct Class {
 impl_parse!(Class, {
     select! { TagType::Comment(c) => c }
         .repeated()
-        .then(select! { TagType::Class(name) => name })
+        .then(select! { TagType::Class(name, parent) => (name, parent) })
         .then(Field::parse().repeated())
         .then(See::parse())
-        .map(|(((desc, name), fields), see)| Self {
+        .map(|(((desc, (name, parent)), fields), see)| Self {
             name,
+            parent,
             desc,
             fields,
             see,

--- a/src/vimdoc.rs
+++ b/src/vimdoc.rs
@@ -119,18 +119,11 @@ pub(crate) fn description(desc: &str) -> String {
     d
 }
 
-macro_rules! header {
-    ($name:expr, $tag:expr) => {{
-        let len = $name.len();
-        if len > 40 || $tag.len() > 40 {
-            format!("{:>80}\n{}\n", format!("*{}*", $tag), $name)
-        } else {
-            format!("{}{:>w$}\n", $name, format!("*{}*", $tag), w = 80 - len)
-        }
-    }};
-    ($name:expr) => {
-        super::header!($name, $name)
-    };
+#[inline]
+pub(crate) fn header(name: &str, tag: &str) -> String {
+    let len = name.len();
+    if len > 40 || tag.len() > 40 {
+        return format!("{:>80}\n{}\n", format!("*{}*", tag), name);
+    }
+    format!("{}{:>w$}\n", name, format!("*{}*", tag), w = 80 - len)
 }
-
-pub(super) use header;

--- a/src/vimdoc/alias.rs
+++ b/src/vimdoc/alias.rs
@@ -11,9 +11,9 @@ impl ToDoc for AliasDoc {
         let mut doc = String::new();
 
         if let Some(prefix) = &n.prefix.right {
-            doc.push_str(&header!(n.name, format!("{prefix}.{}", n.name)));
+            doc.push_str(&header(&n.name, &format!("{prefix}.{}", n.name)));
         } else {
-            doc.push_str(&header!(n.name));
+            doc.push_str(&header(&n.name, &n.name));
         }
 
         if !n.desc.is_empty() {

--- a/src/vimdoc/class.rs
+++ b/src/vimdoc/class.rs
@@ -14,10 +14,17 @@ impl ToDoc for ClassDoc {
     fn to_doc(n: &Self::N, s: &super::Settings) -> String {
         let mut doc = String::new();
 
+        let name = format!(
+            "{}{}",
+            n.name,
+            n.parent
+                .as_ref()
+                .map_or(String::new(), |parent| format!(" : {parent}"))
+        );
         if let Some(prefix) = &n.prefix.right {
-            doc.push_str(&header!(n.name, format!("{prefix}.{}", n.name)));
+            doc.push_str(&header(&name, &format!("{prefix}.{}", n.name)));
         } else {
-            doc.push_str(&header!(n.name));
+            doc.push_str(&header(&name, &n.name));
         }
 
         if !n.desc.is_empty() {

--- a/src/vimdoc/func.rs
+++ b/src/vimdoc/func.rs
@@ -27,9 +27,9 @@ impl ToDoc for FuncDoc {
             format!("{}{}()", n.prefix.left.as_deref().unwrap_or_default(), n.op)
         };
 
-        doc.push_str(&header!(
-            name_with_param,
-            &format!("{}{}", n.prefix.right.as_deref().unwrap_or_default(), n.op)
+        doc.push_str(&header(
+            &name_with_param,
+            &format!("{}{}", n.prefix.right.as_deref().unwrap_or_default(), n.op),
         ));
 
         if !n.desc.is_empty() {

--- a/src/vimdoc/type.rs
+++ b/src/vimdoc/type.rs
@@ -10,9 +10,9 @@ impl ToDoc for TypeDoc {
     fn to_doc(n: &Self::N, s: &super::Settings) -> String {
         let mut doc = String::new();
 
-        doc.push_str(&header!(
+        doc.push_str(&header(
             &format!("{}{}", n.prefix.left.as_deref().unwrap_or_default(), n.op),
-            &format!("{}{}", n.prefix.right.as_deref().unwrap_or_default(), n.op)
+            &format!("{}{}", n.prefix.right.as_deref().unwrap_or_default(), n.op),
         ));
 
         let (extract, desc) = &n.desc;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -132,6 +132,9 @@ fn classes() {
     ---@field pre_hook fun(ctx:CommentCtx):string Function to be called before comment/uncomment
     ---@field post_hook fun(ctx:CommentCtx) Function to be called after comment/uncomment
 
+    ---@class XMen : Homosapien
+    ---@field power number Power quantifier
+
     return U
     ";
 
@@ -170,6 +173,12 @@ CommentConfig                                                    *CommentConfig*
 
         {pre_hook}   (fun(ctx:CommentCtx):string)  Function to be called before comment/uncomment
         {post_hook}  (fun(ctx:CommentCtx))         Function to be called after comment/uncomment
+
+
+XMen : Homosapien                                                         *XMen*
+
+    Fields: ~
+        {power}  (number)  Power quantifier
 
 
 "

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -102,6 +102,9 @@ end
 ---@field protected heart boolean Heart is protected
 ---@field private IQ number We need to hide this
 
+---@class XMen : Human
+---@field power number Power quantifier
+
 ---Creates a Human
 ---@return Human
 ---@usage `require('Human'):create()`


### PR DESCRIPTION
This PR now correctly parses any `---@class` which, optionally, extends from another class.

* Syntax

```lua
---@class <name>[: <parent>]
```