### PR TITLE
feat: support identifier enum variant

### DIFF
--- a/emmylua.md
+++ b/emmylua.md
@@ -645,7 +645,8 @@ You can define a (pseudo) enum using [`---@alias`](#alias).
 
 ```lua
 ---@alias <name> <type>
----| '<value>' [# description]
+---| '<literal>' [# description]
+---| `<identifier>` [# description]
 ```
 
 - Input
@@ -660,7 +661,7 @@ local U = {}
 ---| '"line"' # Vertical motion
 ---| '"char"' # Horizontal motion
 ---| 'v'
----| 'V' # Visual Line Mode
+---| `some.ident` # Some identifier
 
 ---Global vim mode
 ---@type VMode
@@ -678,10 +679,10 @@ VMode                                                                    *VMode*
     Read `:h map-operator`
 
     Variants: ~
-        ("line")  Vertical motion
-        ("char")  Horizontal motion
-        (v)
-        (V)       Visual Line Mode
+        ("line")      Vertical motion
+        ("char")      Horizontal motion
+        ("v")
+        (some.ident)  Some identifier
 
 
 U.VMODE                                                                *U.VMODE*

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -1,6 +1,24 @@
 use std::fmt::Display;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Member {
+    Literal(String),
+    Ident(String),
+}
+
+impl Display for Member {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Literal(lit) => f.write_str(&format!(
+                r#""{}""#,
+                lit.trim_start_matches('"').trim_end_matches('"')
+            )),
+            Self::Ident(ident) => f.write_str(ident),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TagType {
     /// ```lua
     /// ---@toc <name>
@@ -63,9 +81,13 @@ pub enum TagType {
     /// ```
     Alias(String, Option<Ty>),
     /// ```lua
-    /// ---| '<value>' [# description]
+    /// ---| '<literal>' [# description]
+    ///
+    /// -- or
+    ///
+    /// ---| `<ident>` [# description]
     /// ```
-    Variant(String, Option<String>),
+    Variant(Member, Option<String>),
     /// ```lua
     /// ---@type <type> [desc]
     /// ```
@@ -166,6 +188,7 @@ pub enum Ty {
     Userdata,
     Lightuserdata,
     Ref(String),
+    Member(Member),
     Array(Box<Ty>),
     Table(Option<(Box<Ty>, Box<Ty>)>),
     Fun(Vec<(Name, Ty)>, Option<Vec<Ty>>),
@@ -234,6 +257,7 @@ impl Display for Ty {
                 f.write_str("|")?;
                 f.write_str(&lhs.to_string())
             }
+            Self::Member(mem) => mem.fmt(f),
         }
     }
 }

--- a/src/parser/tags/alias.rs
+++ b/src/parser/tags/alias.rs
@@ -1,14 +1,14 @@
 use chumsky::{prelude::choice, select, Parser};
 
 use crate::{
-    lexer::{TagType, Ty},
+    lexer::{Member, TagType, Ty},
     parser::{impl_parse, Prefix},
 };
 
 #[derive(Debug, Clone)]
 pub enum AliasKind {
     Type(Ty),
-    Enum(Vec<(String, Option<String>)>),
+    Enum(Vec<(Member, Option<String>)>),
 }
 
 #[derive(Debug, Clone)]

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -576,7 +576,7 @@ fn alias_and_type() {
     ---| '"line"' # Vertical motion
     ---| '"char"' # Horizontal motion
     ---| 'v'
-    ---| 'V' # Visual Line Mode
+    ---| `some.ident` # Some identifier
 
     ---Returns all the content of the buffer
     ---@return Lines
@@ -619,10 +619,10 @@ VMode                                                                    *VMode*
     Read `:h map-operator`
 
     Variants: ~
-        ("line")  Vertical motion
-        ("char")  Horizontal motion
-        (v)
-        (V)       Visual Line Mode
+        ("line")      Vertical motion
+        ("char")      Horizontal motion
+        ("v")
+        (some.ident)  Some identifier
 
 
 U.get_all()                                                          *U.get_all*

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -1,5 +1,5 @@
 use chumsky::Parser;
-use lemmy_help::lexer::{Lexer, Name, Ty};
+use lemmy_help::lexer::{Lexer, Member, Name, Ty};
 
 macro_rules! b {
     ($t:expr) => {
@@ -201,10 +201,13 @@ fn types() {
     check!(
         r#"'"g@"'|string[]|'"g@$"'|number"#,
         Ty::Union(
-            b!(Ty::Ref(r#""g@""#.into())),
+            b!(Ty::Member(Member::Literal(r#""g@""#.into()))),
             b!(Ty::Union(
                 b!(Ty::Array(b!(Ty::String))),
-                b!(Ty::Union(b!(Ty::Ref(r#""g@$""#.into())), b!(Ty::Number)))
+                b!(Ty::Union(
+                    b!(Ty::Member(Member::Literal(r#""g@$""#.into()))),
+                    b!(Ty::Number)
+                ))
             ))
         )
     );


### PR DESCRIPTION
This PR adds support for enum variant which includes identifier as its member.

- Literal variant

> Member will always be treated as string value. This matches the LLS behavior.

```lua
---| '<literal>' [# description]
```

- Identifier variant

```lua
---| `<identifier>` [# description]
```

#### Emmylua

```lua
---Vim operator-mode motions.
---
---Read `:h map-operator`
---@alias VMode
---| '"line"' # Vertical motion
---| '"char"' # Horizontal motion
---| 'v'
---| `some.ident` # Some identifier
```

#### Help

```help
VMode                                                                    *VMode*
    Vim operator-mode motions.

    Read `:h map-operator`

    Variants: ~
        ("line")      Vertical motion
        ("char")      Horizontal motion
        ("v")
        (some.ident)  Some identifier
```

#### Screenshot

- Inline enum

![](https://user-images.githubusercontent.com/24727447/207504703-8ac9c172-86d9-46fc-b6da-1ae8283cc9b1.png)

- `---@alias` enum

![](https://user-images.githubusercontent.com/24727447/207504237-a58948a7-c5a4-4710-b8fa-792bb8bf406e.png)