### PR TITLE
feat: support `---@{protected,package,public}`

### DIFF
--- a/emmylua.md
+++ b/emmylua.md
@@ -694,12 +694,18 @@ U.VMODE                                                                *U.VMODE*
 
 ### Private
 
-This tag can be used to discard any part of the code that is exported but it is not considered to be a part of the public API
+One of the following tags can be used to discard any part of the code that is not considered a part of the public API. All these tags behaves exactly same when it comes to vimdoc generation but have different use cases when used together with LLS.
+
+- Spec: [`---@private`](https://github.com/sumneko/lua-language-server/wiki/Annotations#private), [`---@protected`](https://github.com/sumneko/lua-language-server/wiki/Annotations#protected), [`---@package`](https://github.com/sumneko/lua-language-server/wiki/Annotations#package)
 
 - Syntax
 
 ```lua
 ---@private
+
+---@protected
+
+---@package
 ```
 
 - Input
@@ -719,9 +725,9 @@ function U.ok()
     print('Ok! I am exported')
 end
 
----@private
+---@protected
 function U.no_emmy()
-    print('Private func with no emmylua!')
+    print('Protected func with no emmylua!')
 end
 
 return U

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -153,6 +153,7 @@ pub enum Scope {
     Public,
     Private,
     Protected,
+    Package,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -676,9 +676,9 @@ fn private() {
         print('Ok! I am exported')
     end
 
-    ---@private
+    ---@protected
     function U.no_emmy()
-        print('Private func with no emmylua!')
+        print('Protected func with no emmylua!')
     end
 
     return U


### PR DESCRIPTION
This adds support for `---@protected`, and `---@package` which act precisely as `---@private`, which is already implemented, hiding any node from the vimdoc. And `---@public` support, which gets parsed and stripped away, and doesn't affect vimdoc in any way.